### PR TITLE
Fix behavior when resource URI has non-empty path

### DIFF
--- a/src/webfinger.js
+++ b/src/webfinger.js
@@ -247,7 +247,7 @@ if (typeof XMLHttpRequest === 'undefined') {
     var host = '';
     if (address.indexOf('://') > -1) {
       // other uri format
-      host = address.replace(/ /g,'').split('://')[1];
+      host = address.replace(/ /g,'').split('/')[2];
     } else {
       // useraddress
       host = address.replace(/ /g,'').split('@')[1];

--- a/test/01-basics-suite.js
+++ b/test/01-basics-suite.js
@@ -169,9 +169,9 @@ define(['require', './../src/webfinger.js'], function (require, amdwf) {
       {
         desc: 'calling with non-acct URI address',
         run: function (env, test) {
-          env.wf.lookup('http://silverbucket.net', function (err, data) {
+          env.wf.lookup('http://silverbucket.net/account/nick', function (err, data) {
             test.assertTypeAnd(err, 'object');
-            test.assert(err.request, 'https://silverbucket.net/.well-known/webfinger?resource=http://silverbucket.net');
+            test.assert(err.url, 'https://silverbucket.net/.well-known/webfinger?resource=http://silverbucket.net/account/nick');
           });
         }
       }


### PR DESCRIPTION
As mentioned in https://github.com/silverbucket/webfinger.js/issues/18#issuecomment-216945176, when looking up `http://silverbucket.net/account/nick`, it concludes that the host is `silverbucket.net/account/nick` instead of `silverbucket.net`. This PR fixes that.