### PR TITLE
Improve build system to separate development and release builds

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -22,5 +22,8 @@ jobs:
       - name: Install Dependencies
         run: bun install
       
-      - name: Run CI Pipeline
-        run: bun run test:ci
+      - name: Run Linting
+        run: bun run lint
+        
+      - name: Run Tests
+        run: bun run test

--- a/package.json
+++ b/package.json
@@ -36,15 +36,14 @@
     "email": "nick@silverbucket.net"
   },
   "scripts": {
-    "build": "bun run tsc && bun scripts/build.js --output .tmp/webfinger.js",
+    "build": "bun run tsc --project tsconfig.dev.json && bun scripts/build.js --output .tmp/webfinger.js",
     "build:release": "bun run tsc && bun scripts/build.js --output dist/webfinger.js",
     "build:clean": "rm -rf dist && bun run build:release",
     "prepublishOnly": "bun run build:clean",
     "lint": "eslint .",
     "test:ts": "bun test",
-    "test:js": "bun test --env-file .env.test-js",
+    "test:js": "TEST_TARGET=js bun test",
     "test": "bun run build && bun run test:ts && bun run test:js",
-    "test:ci": "bun run lint && bun run test",
     "prepare-release": "./scripts/prepare-release.sh",
     "prepare-release:patch": "./scripts/prepare-release.sh patch",
     "prepare-release:minor": "./scripts/prepare-release.sh minor",

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./.tmp"
+  }
+}


### PR DESCRIPTION
## Summary

This PR improves the build system to clearly separate development and release builds, preventing accidental modifications to the `dist/` directory during development.

- ✅ **Development builds**: Uses `tsconfig.dev.json` → outputs to `.tmp/` (temporary)
- ✅ **Release builds**: Uses `tsconfig.json` → outputs to `dist/` (release only)
- ✅ **CI improvements**: Separates linting and testing steps for better clarity
- ✅ **Test improvements**: Uses `TEST_TARGET` environment variable instead of `.env` file

## Changes Made

### Build Configuration
- **New file**: `tsconfig.dev.json` - Development TypeScript config that outputs to `.tmp/`
- **Updated**: `package.json` - Modified `build` script to use development config
- **Preserved**: `build:release` still uses main `tsconfig.json` for release builds

### CI/Testing 
- **Updated**: `.github/workflows/compliance.yml` - Separated lint and test steps
- **Updated**: `package.json` - Simplified `test:js` to use environment variable
- **Removed**: `test:ci` script (replaced with individual steps)

## Problem Solved

Previously, `tsconfig.json` had `outDir: './dist'` causing ALL TypeScript compilation to write to `dist/`, even during development and testing. This meant:

❌ **Before**: Development builds modified `dist/` (undesirable)  
✅ **After**: Development builds use `.tmp/`, `dist/` only for releases

## Test Plan

- [x] `bun run build` - Compiles to `.tmp/` for development
- [x] `bun run build:release` - Compiles to `dist/` for releases  
- [x] `bun run test` - Runs both TypeScript and JavaScript tests
- [x] CI workflow runs successfully with separated steps

🤖 Generated with [Claude Code](https://claude.ai/code)