### PR TITLE
Refine content-type checking to be less strict

### DIFF
--- a/src/webfinger.test.ts
+++ b/src/webfinger.test.ts
@@ -129,14 +129,14 @@ describe('WebFinger', () => {
   });
 
   describe('Content-Type Warnings', () => {
-    it('should warn when server returns non-JRD content type', async () => {
+    it('should debug log when server returns application/json', async () => {
       const originalFetch = globalThis.fetch;
-      const originalConsoleWarn = console.warn;
-      let warningMessage = '';
+      const originalConsoleDebug = console.debug;
+      let debugMessage = '';
 
-      // Mock console.warn to capture warnings
-      console.warn = (message: string) => {
-        warningMessage = message;
+      // Mock console.debug to capture debug messages
+      console.debug = (message: string) => {
+        debugMessage = message;
       };
 
       // Mock fetch to return application/json instead of application/jrd+json
@@ -156,8 +156,42 @@ describe('WebFinger', () => {
         const testWf = new WebFinger({ request_timeout: 1000 });
         await testWf.lookup('test@example.com');
         
-        expect(warningMessage).toContain('WebFinger: Server returned content-type "application/json"');
-        expect(warningMessage).toContain('application/jrd+json');
+        expect(debugMessage).toContain('WebFinger: Server uses "application/json"');
+        expect(debugMessage).toContain('RFC 7033 recommended "application/jrd+json"');
+      } finally {
+        globalThis.fetch = originalFetch;
+        console.debug = originalConsoleDebug;
+      }
+    });
+
+    it('should warn when server returns unexpected content type', async () => {
+      const originalFetch = globalThis.fetch;
+      const originalConsoleWarn = console.warn;
+      let warningMessage = '';
+
+      // Mock console.warn to capture warnings
+      console.warn = (message: string) => {
+        warningMessage = message;
+      };
+
+      // Mock fetch to return unexpected content type
+      globalThis.fetch = async () => {
+        return new Response(JSON.stringify({
+          subject: 'acct:test@example.com',
+          links: []
+        }), {
+          status: 200,
+          headers: {
+            'content-type': 'text/html'
+          }
+        });
+      };
+
+      try {
+        const testWf = new WebFinger({ request_timeout: 1000 });
+        await testWf.lookup('test@example.com');
+        
+        expect(warningMessage).toContain('WebFinger: Server returned unexpected content-type "text/html"');
         expect(warningMessage).toContain('RFC 7033');
       } finally {
         globalThis.fetch = originalFetch;

--- a/src/webfinger.ts
+++ b/src/webfinger.ts
@@ -158,12 +158,19 @@ export default class WebFinger {
       throw new WebFingerError('error during request', response.status);
     }
 
-    // Check Content-Type and warn if not application/jrd+json
+    // Check Content-Type for RFC 7033 compliance (informational only)
     const contentType = response.headers.get('content-type') || '';
-    if (!contentType.toLowerCase().startsWith('application/jrd+json')) {
+    const lowerContentType = contentType.toLowerCase();
+    
+    if (!lowerContentType.includes('application/jrd+json') && !lowerContentType.includes('application/json')) {
       console.warn(
-        `WebFinger: Server returned content-type "${contentType}" instead of "application/jrd+json". ` +
-        'This server may not be fully compliant with the WebFinger specification (RFC 7033).'
+        `WebFinger: Server returned unexpected content-type "${contentType}". ` +
+        'Expected "application/jrd+json" per RFC 7033.'
+      );
+    } else if (lowerContentType.includes('application/json') && !lowerContentType.includes('application/jrd+json')) {
+      // Use console.debug for less intrusive logging - many servers use application/json
+      console.debug(
+        `WebFinger: Server uses "application/json" instead of RFC 7033 recommended "application/jrd+json".`
       );
     }
 


### PR DESCRIPTION
## Summary
Refines the content-type warning feature (from #97/#4) to be more pragmatic and less intrusive after research into RFC 7033 and real-world WebFinger server implementations.

## Key Changes
- **Less aggressive logging**: Use `console.debug` for common `application/json` usage instead of warnings
- **Reserve warnings**: Only warn for truly unexpected content-types (not JSON-based)
- **Improved messaging**: More balanced tone that acknowledges real-world practices

## Rationale
After analyzing RFC 7033 and testing against real servers, many established WebFinger implementations use `application/json` which is functionally equivalent to `application/jrd+json`. The RFC emphasizes the JRD format more than the specific media type header.

## Behavior Changes
**Before**: All non-`application/jrd+json` responses triggered console warnings
**After**: 
- `application/jrd+json` → No logging (ideal)
- `application/json` → Debug message only (common practice)  
- Other types → Warning (truly unexpected)

## Testing
- Updated test suite to cover the refined behavior
- Integration tests show debug messages instead of warnings for common servers
- All functionality preserved

This makes the feature more developer-friendly while still providing RFC compliance guidance.