### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -340,12 +340,16 @@
     };
 
     function clearError() {
-      document.getElementById('error').innerHTML = '';
+      const errorElement = document.getElementById('error');
+      errorElement.textContent = '';
     }
 
     function showError(message, address) {
-      document.getElementById('error').innerHTML =
-        `<div class="error">${message} for ${address}</div>`;
+      const errorElement = document.getElementById('error');
+      const errorDiv = document.createElement('div');
+      errorDiv.className = 'error';
+      errorDiv.textContent = `${message} for ${address}`;
+      errorElement.appendChild(errorDiv);
     }
 
     function tryExample(address) {


### PR DESCRIPTION
Potential fix for [https://github.com/silverbucket/webfinger.js/security/code-scanning/2](https://github.com/silverbucket/webfinger.js/security/code-scanning/2)

To fix the issue, we need to ensure that any untrusted data (like `address`) is properly escaped before being inserted into the DOM. Instead of using `innerHTML`, which interprets the string as HTML, we can use `textContent` to safely insert the text as plain text. This approach prevents any HTML or JavaScript from being executed, mitigating the XSS risk.

The changes will involve:
1. Replacing the use of `innerHTML` in the `showError` function with `textContent`.
2. Modifying the `showError` function to create and append DOM elements programmatically, ensuring that all text is treated as plain text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
