### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on: 
   push:
     branches: [ master, main ]


### PR DESCRIPTION
Potential fix for [https://github.com/silverbucket/webfinger.js/security/code-scanning/1](https://github.com/silverbucket/webfinger.js/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the minimum required permissions for the jobs. Since the jobs only need to read the repository contents (to checkout code and run tests), you should set `contents: read` at the workflow level. This will apply to all jobs in the workflow unless overridden at the job level. The change should be made at the top level of the `.github/workflows/compliance.yml` file, immediately after the `name:` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
