### PR TITLE
Fix HTTP fallback functionality when tls_only is false (#116)

### DIFF
--- a/src/webfinger.ts
+++ b/src/webfinger.ts
@@ -675,19 +675,20 @@ export default class WebFinger {
           const JRD = await this.fetchJRD(result.idx.links.webfist[0].href);
           return await WebFinger.processJRD(URL, JRD);
         }
+        throw new WebFingerError('webfist fallback failed');
       } else {
-        throw err instanceof Error ? err : new WebFingerError(String(err))
+        throw err instanceof Error ? err : new WebFingerError(String(err));
       }
     }
 
     const __call = async (): Promise<WebFingerResult> => {
       // make request
       const URL = __buildURL();
-      const JRD = await this.fetchJRD(URL).catch(__fallbackChecks);
-      if (typeof JRD === "string") {
+      try {
+        const JRD = await this.fetchJRD(URL);
         return WebFinger.processJRD(URL, JRD);
-      } else {
-        throw new WebFingerError("unknown error");
+      } catch (err) {
+        return await __fallbackChecks(err as Error);
       }
     }
 


### PR DESCRIPTION
Fixes a bug where HTTP fallback was not working when tls_only: false was configured. The issue was caused by a type mismatch in the fallback control flow where __fallbackChecks returned a WebFingerResult but the code expected a string.

  Changes:
  - Fixed the control flow in __call() to properly handle fallback results by using try/catch instead of .catch() chaining
  
  Testing:
  - Added test case: should fallback to HTTP when tls_only is false and HTTPS fails
  - Added test case: should NOT fallback to HTTP when tls_only is true (default)

  This fix ensures that when tls_only: false is explicitly set and HTTPS requests fail, the client properly falls back to HTTP while maintaining the secure default behavior of TLS-only.

Resolves #116