### PR TITLE
Fix gh-pages deploy failing on dirty working tree

### DIFF
--- a/scripts/deploy-to-ghpages.sh
+++ b/scripts/deploy-to-ghpages.sh
@@ -21,13 +21,19 @@ echo -e "${GREEN}🌐 Deploying demo v$VERSION to GitHub Pages...${NC}"
 
 # Remember current branch
 CURRENT_BRANCH=$(git branch --show-current)
+STASH_CREATED=false
 echo -e "${YELLOW}📍 Current branch: $CURRENT_BRANCH${NC}"
 
 # Function to return to original branch on exit
 cleanup() {
-    echo -e "${YELLOW}🔄 Returning to branch: $CURRENT_BRANCH${NC}"
-    git checkout "$CURRENT_BRANCH" 2>/dev/null || true
-    git stash pop 2>/dev/null || true
+    if git checkout "$CURRENT_BRANCH" 2>/dev/null; then
+        echo -e "${YELLOW}🔄 Returned to branch: $CURRENT_BRANCH${NC}"
+        if [ "$STASH_CREATED" = true ]; then
+            git stash pop 2>/dev/null || true
+        fi
+    else
+        echo -e "${YELLOW}⚠️  Failed to return to branch: $CURRENT_BRANCH. Leaving any stashed changes untouched.${NC}"
+    fi
 }
 trap cleanup EXIT
 
@@ -35,8 +41,12 @@ trap cleanup EXIT
 echo -e "${YELLOW}📥 Fetching gh-pages branch...${NC}"
 git fetch origin gh-pages
 
-echo -e "${YELLOW}📦 Stashing any uncommitted changes...${NC}"
-git stash --include-untracked
+# Stash uncommitted changes (e.g. bun.lock modified during import tests)
+if ! git diff --quiet || ! git diff --cached --quiet || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+    echo -e "${YELLOW}📦 Stashing uncommitted changes...${NC}"
+    git stash push -u -m "deploy-to-ghpages: temporary stash"
+    STASH_CREATED=true
+fi
 
 echo -e "${YELLOW}🌿 Switching to gh-pages branch...${NC}"
 git checkout gh-pages


### PR DESCRIPTION
## Summary

The prepare-release workflow fails at the "Deploy to GitHub Pages" step because `spec/imports/bun/bun.lock` gets modified during import tests but isn't committed to the release branch. When the deploy script tries to `git checkout gh-pages`, git refuses due to the dirty file.

This fix stashes uncommitted changes before switching branches and restores them on cleanup.

## Test plan

- [ ] Re-run the prepare-release workflow and verify the gh-pages deploy step succeeds