### PR TITLE
Fix YAML parsing error in publish-on-merge workflow

### DIFF
--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -155,21 +155,26 @@ jobs:
           echo "3. Verify publication at https://www.npmjs.com/package/webfinger.js" >> $GITHUB_STEP_SUMMARY
           
           # Create GitHub issue for tracking
-          gh issue create --title "🚨 NPM Publish Failed for v${{ steps.version.outputs.version }}" \
-            --body "The automated release process completed successfully except for NPM publishing. 
+          VERSION="v${{ steps.version.outputs.version }}"
+          RELEASE_URL="https://github.com/silverbucket/webfinger.js/releases/tag/$VERSION"
+          gh issue create --title "NPM Publish Failed for $VERSION" \
+            --body "$(cat <<ISSUE_BODY
+          The automated release process completed successfully except for NPM publishing.
 
-**Status:**
-- ✅ Git tag created: v${{ steps.version.outputs.version }}
-- ✅ GitHub release created: https://github.com/silverbucket/webfinger.js/releases/tag/v${{ steps.version.outputs.version }}
-- ❌ NPM publish failed
+          **Status:**
+          - Git tag created: $VERSION
+          - GitHub release created: $RELEASE_URL
+          - NPM publish failed
 
-**Manual Fix Required:**
-Run \`npm publish\` locally after checking authentication and network connectivity.
+          **Manual Fix Required:**
+          Run \`npm publish\` locally after checking authentication and network connectivity.
 
-**Verification:**
-Check https://www.npmjs.com/package/webfinger.js to confirm publication.
+          **Verification:**
+          Check https://www.npmjs.com/package/webfinger.js to confirm publication.
 
-This issue can be closed once NPM publish is completed manually." \
+          This issue can be closed once NPM publish is completed manually.
+          ISSUE_BODY
+          )" \
             --label "release" \
             --label "npm"
         env:


### PR DESCRIPTION
## Summary

- The `publish-on-merge.yml` workflow failed on the v3.0.0 release merge because GitHub could not parse the YAML file
- Root cause: the `gh issue create --body` inline string contained `**Status:**` at zero indentation, which broke out of the YAML `|` block scalar and was interpreted as a YAML alias reference (`*Status:**`)
- Fix: use a heredoc for the issue body content and ensure all lines stay properly indented within the YAML block

## Test plan

- [x] YAML validates correctly with js-yaml parser
- [x] `bun run lint` passes
- [x] `bun run test` passes (all 41 unit, 28 integration, 17 browser tests)
- [ ] After merge, verify workflow file is recognized by GitHub Actions (shows proper name instead of file path)