### PR TITLE
fix: make publish workflow idempotent and robust

### DIFF
--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -34,9 +34,11 @@ jobs:
       - name: Build project
         run: bun run build
 
-      - name: Setup npm authentication
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Get version from package.json
         id: version
@@ -106,25 +108,31 @@ jobs:
 
       - name: Create and push git tag
         run: |
-          git tag v${{ steps.version.outputs.version }}
-          git push origin v${{ steps.version.outputs.version }}
+          git tag -f v${{ steps.version.outputs.version }}
+          git push --force origin v${{ steps.version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
+        run: |
+          VERSION="v${{ steps.version.outputs.version }}"
+          if gh release view "$VERSION" > /dev/null 2>&1; then
+            gh release edit "$VERSION" \
+              --title "Release $VERSION" \
+              --notes-file current_release_notes.txt
+          else
+            gh release create "$VERSION" \
+              --title "Release $VERSION" \
+              --notes-file current_release_notes.txt
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.version.outputs.version }}
-          release_name: Release v${{ steps.version.outputs.version }}
-          body_path: current_release_notes.txt
-          draft: false
-          prerelease: false
 
       - name: Publish to npm
         id: npm_publish
         run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Add publish summary
         run: |
@@ -175,8 +183,7 @@ jobs:
           This issue can be closed once NPM publish is completed manually.
           ISSUE_BODY
           )" \
-            --label "release" \
-            --label "npm"
+            --label "bug"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -106,22 +106,26 @@ jobs:
         id: npm_check
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          if npm view "webfinger.js@${VERSION}" version > /dev/null 2>&1; then
-            echo "Version ${VERSION} is already published to npm, skipping release."
+          NPM_VIEW_OUTPUT="$(npm view "webfinger.js@${VERSION}" version 2>&1)" && {
+            echo "Version ${VERSION} is already published to npm, skipping publish."
             echo "already_published=true" >> $GITHUB_OUTPUT
-          else
-            echo "Version ${VERSION} not yet on npm, proceeding with release."
-            echo "already_published=false" >> $GITHUB_OUTPUT
-          fi
+          } || {
+            if printf '%s\n' "$NPM_VIEW_OUTPUT" | grep -qE 'E404|404 Not Found|is not in this registry'; then
+              echo "Version ${VERSION} not yet on npm, proceeding with release."
+              echo "already_published=false" >> $GITHUB_OUTPUT
+            else
+              echo "Failed to check npm registry for version ${VERSION}:"
+              printf '%s\n' "$NPM_VIEW_OUTPUT"
+              exit 1
+            fi
+          }
 
       - name: Configure Git
-        if: steps.npm_check.outputs.already_published == 'false'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
       - name: Create and push git tag
-        if: steps.npm_check.outputs.already_published == 'false'
         run: |
           git tag -f v${{ steps.version.outputs.version }}
           git push --force origin v${{ steps.version.outputs.version }}
@@ -129,7 +133,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
-        if: steps.npm_check.outputs.already_published == 'false'
         run: |
           VERSION="v${{ steps.version.outputs.version }}"
           if gh release view "$VERSION" > /dev/null 2>&1; then
@@ -154,9 +157,9 @@ jobs:
       - name: Add already published summary
         if: steps.npm_check.outputs.already_published == 'true'
         run: |
-          echo "## ⏭️ Version Already Published" >> $GITHUB_STEP_SUMMARY
+          echo "## ⏭️ NPM Version Already Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "v${{ steps.version.outputs.version }} is already on npm. No action taken." >> $GITHUB_STEP_SUMMARY
+          echo "v${{ steps.version.outputs.version }} is already on npm. Git tag and GitHub release were updated, npm publish skipped." >> $GITHUB_STEP_SUMMARY
 
       - name: Add publish summary
         if: steps.npm_check.outputs.already_published == 'false'

--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -102,12 +102,26 @@ jobs:
             exit 1
           fi
 
+      - name: Check if version already published to npm
+        id: npm_check
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if npm view "webfinger.js@${VERSION}" version > /dev/null 2>&1; then
+            echo "Version ${VERSION} is already published to npm, skipping release."
+            echo "already_published=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version ${VERSION} not yet on npm, proceeding with release."
+            echo "already_published=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Configure Git
+        if: steps.npm_check.outputs.already_published == 'false'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
       - name: Create and push git tag
+        if: steps.npm_check.outputs.already_published == 'false'
         run: |
           git tag -f v${{ steps.version.outputs.version }}
           git push --force origin v${{ steps.version.outputs.version }}
@@ -115,6 +129,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
+        if: steps.npm_check.outputs.already_published == 'false'
         run: |
           VERSION="v${{ steps.version.outputs.version }}"
           if gh release view "$VERSION" > /dev/null 2>&1; then
@@ -130,12 +145,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to npm
+        if: steps.npm_check.outputs.already_published == 'false'
         id: npm_publish
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Add already published summary
+        if: steps.npm_check.outputs.already_published == 'true'
+        run: |
+          echo "## ⏭️ Version Already Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "v${{ steps.version.outputs.version }} is already on npm. No action taken." >> $GITHUB_STEP_SUMMARY
+
       - name: Add publish summary
+        if: steps.npm_check.outputs.already_published == 'false'
         run: |
           echo "## 📦 NPM Publish Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Switch npm auth from manual `.npmrc` to `actions/setup-node@v4` with `NODE_AUTH_TOKEN` (standard approach)
- Replace deprecated `actions/create-release@v1` with `gh` CLI, handling existing releases on re-runs
- Make git tag step idempotent (`git tag -f`) so workflow re-runs don't fail on existing tags
- Fix failure handler using non-existent repo labels (`release`/`npm` → `bug`)

## Test plan

- [ ] Merge this PR, then delete existing v3.0.1 tag/release and re-run prepare-release
- [ ] Verify npm publish succeeds with the updated NPM_TOKEN
- [ ] Verify GitHub release is created correctly