### PR TITLE
fix: add --provenance to npm publish for CI compatibility

### DIFF
--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Publish to npm
         if: steps.npm_check.outputs.already_published == 'false'
         id: npm_publish
-        run: npm publish
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Adds `--provenance` flag to `npm publish` in the publish workflow, leveraging the existing `id-token: write` permission for OIDC-based attestation
- This is a best practice for GitHub Actions npm publishing and improves supply-chain security
- The v3.0.2 publish failed with `EOTP` because the NPM token type requires interactive OTP — the `NPM_TOKEN` secret should also be regenerated as an Automation token to fully resolve the issue