### PR TITLE
fix: preserve link properties objects in processJRD

### DIFF
--- a/src/webfinger.test.ts
+++ b/src/webfinger.test.ts
@@ -718,4 +718,49 @@ describe('WebFinger', () => {
       }
     });
   });
+
+  describe('RFC 7033 Link Properties', () => {
+    it('should preserve link properties objects instead of converting to string', async () => {
+      const originalFetch = globalThis.fetch;
+
+      globalThis.fetch = async () => {
+        return new Response(JSON.stringify({
+          subject: 'acct:test@example.com',
+          links: [
+            {
+              rel: 'http://webfinger.net/rel/avatar',
+              href: 'https://example.com/avatar.png',
+              type: 'image/png',
+              properties: {
+                'http://example.com/ns/size': '128',
+                'http://example.com/ns/default': null
+              }
+            }
+          ]
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/jrd+json' }
+        });
+      };
+
+      try {
+        const testWf = new WebFinger({
+          request_timeout: 1000,
+          allow_private_addresses: true
+        });
+        const result = await testWf.lookup('test@example.com');
+
+        const avatarLinks = result.idx.links.avatar;
+        expect(avatarLinks).toHaveLength(1);
+        expect(avatarLinks[0].href).toBe('https://example.com/avatar.png');
+        expect(typeof avatarLinks[0].properties).toBe('object');
+        expect(avatarLinks[0].properties).toEqual({
+          'http://example.com/ns/size': '128',
+          'http://example.com/ns/default': null
+        });
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
 });

--- a/src/webfinger.ts
+++ b/src/webfinger.ts
@@ -104,8 +104,10 @@ export type LinkObject = {
   rel: string;
   /** MIME type (optional) */
   type?: string;
+  /** RFC 7033 link properties */
+  properties?: Record<string, string | null>;
   /** Additional properties */
-  [key: string]: string | undefined;
+  [key: string]: string | Record<string, string | null> | undefined;
 }
 
 /**
@@ -460,7 +462,11 @@ export default class WebFinger {
             rel: String(link.rel || '')
           };
           Object.keys(link).map(function (item) {
-            entry[item] = String(link[item]);
+            if (typeof link[item] === 'object' && link[item] !== null) {
+              entry[item] = link[item] as Record<string, string | null>;
+            } else {
+              entry[item] = String(link[item]);
+            }
           });
           result.idx.links[mappedKey].push(entry);
         }


### PR DESCRIPTION
## Summary

Fixes #155. The `processJRD` function was casting all link object values to strings via `String()`, which destroyed RFC 7033 `properties` objects by converting them to `"[object Object]"`. This broke libraries like remotestorage.js that rely on link properties for discovery.

- Preserve object-typed link values (like `properties`) instead of stringifying them
- Update `LinkObject` type to include explicit `properties` field as `Record<string, string | null>`
- Add test verifying link properties with both string and null values are preserved

## Test plan

- [x] `bun run lint` passes
- [x] `bun run test` passes (42 unit tests, 28 integration tests, 17 browser tests)
- [x] New test covers link `properties` with string and null values per RFC 7033