### PR TITLE
Enforce per-request WebFinger timeouts

### DIFF
--- a/spec/browser/browser.integration.js
+++ b/spec/browser/browser.integration.js
@@ -14,6 +14,32 @@ async function loadWebFinger() {
   });
 }
 
+function createAbortError() {
+  const abortError = new Error('Aborted');
+  abortError.name = 'AbortError';
+  return abortError;
+}
+
+function createAbortablePendingFetch(onAbort) {
+  return (_url, init = {}) => new Promise((_resolve, reject) => {
+    const signal = init.signal;
+    if (!signal) {
+      return;
+    }
+
+    if (signal.aborted) {
+      if (onAbort) onAbort();
+      reject(createAbortError());
+      return;
+    }
+
+    signal.addEventListener('abort', () => {
+      if (onAbort) onAbort();
+      reject(createAbortError());
+    }, { once: true });
+  });
+}
+
 describe('WebFinger Browser Tests', () => {
   let WebFinger;
   let webfinger;
@@ -302,6 +328,36 @@ describe('WebFinger Browser Tests', () => {
         throw new Error('Should have thrown');
       } catch (err) {
         expect(err.message).to.include('private or internal addresses are not allowed');
+      }
+    });
+  });
+
+  describe('Request Timeout', () => {
+    it('should timeout stalled requests in the browser bundle', async () => {
+      const originalFetch = window.fetch;
+      let abortCount = 0;
+
+      window.fetch = createAbortablePendingFetch(() => {
+        abortCount++;
+      });
+
+      try {
+        const timeoutWf = new WebFinger({
+          allow_private_addresses: true,
+          request_timeout: 20,
+          uri_fallback: false
+        });
+
+        try {
+          await timeoutWf.lookup('test@example.com');
+          throw new Error('Should have thrown');
+        } catch (err) {
+          expect(err.message).to.include('request timed out');
+        }
+
+        expect(abortCount).to.equal(1);
+      } finally {
+        window.fetch = originalFetch;
       }
     });
   });

--- a/src/webfinger.test.ts
+++ b/src/webfinger.test.ts
@@ -657,6 +657,49 @@ describe('WebFinger', () => {
       }
     });
 
+    it('should timeout when headers arrive but the body stalls', async () => {
+      const originalFetch = globalThis.fetch;
+      let bodyAbortCount = 0;
+
+      globalThis.fetch = (_url: string | Request, init?: RequestInit) => {
+        const signal = init?.signal;
+        const body = new ReadableStream({
+          start(controller) {
+            if (!signal) return;
+            const onAbort = () => {
+              bodyAbortCount++;
+              controller.error(createAbortError());
+            };
+            if (signal.aborted) {
+              onAbort();
+              return;
+            }
+            signal.addEventListener('abort', onAbort, { once: true });
+          }
+        });
+
+        return Promise.resolve(new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'application/jrd+json' }
+        }));
+      };
+
+      try {
+        const timeoutWf = new WebFinger({
+          allow_private_addresses: true,
+          request_timeout: 20,
+          uri_fallback: false
+        });
+
+        await expect(timeoutWf.lookup('test@example.com'))
+          .rejects.toThrow('request timed out');
+
+        expect(bodyAbortCount).toBe(1);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
     it('should give redirect follow-up requests their own timeout budget', async () => {
       const originalFetch = globalThis.fetch;
       const requestedUrls: string[] = [];

--- a/src/webfinger.test.ts
+++ b/src/webfinger.test.ts
@@ -8,6 +8,32 @@ type MockProcess = {
   };
 };
 
+function createAbortError(): Error {
+  const abortError = new Error('Aborted');
+  abortError.name = 'AbortError';
+  return abortError;
+}
+
+function createAbortablePendingFetch(onAbort?: () => void) {
+  return (_url: string | Request, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+    const signal = init?.signal;
+    if (!signal) {
+      return;
+    }
+
+    if (signal.aborted) {
+      onAbort?.();
+      reject(createAbortError());
+      return;
+    }
+
+    signal.addEventListener('abort', () => {
+      onAbort?.();
+      reject(createAbortError());
+    }, { once: true });
+  });
+}
+
 describe('WebFinger', () => {
   let webfinger: WebFinger;
 
@@ -559,6 +585,116 @@ describe('WebFinger', () => {
         
         await expect(webfinger.lookup('test@example.com')).rejects.toThrow();
         expect(httpAttempted).toBe(false);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
+
+  describe('Request Timeout', () => {
+    it('should timeout a stalled request attempt', async () => {
+      const originalFetch = globalThis.fetch;
+      let abortCount = 0;
+
+      globalThis.fetch = createAbortablePendingFetch(() => {
+        abortCount++;
+      });
+
+      try {
+        const timeoutWf = new WebFinger({
+          allow_private_addresses: true,
+          request_timeout: 20,
+          uri_fallback: false
+        });
+
+        await expect(timeoutWf.lookup('test@example.com'))
+          .rejects.toThrow('request timed out');
+
+        expect(abortCount).toBe(1);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('should fallback to HTTP after an HTTPS timeout when tls_only is false', async () => {
+      const originalFetch = globalThis.fetch;
+      let requestCount = 0;
+      let abortCount = 0;
+
+      globalThis.fetch = (url: string | Request, init?: RequestInit) => {
+        requestCount++;
+        const urlString = typeof url === 'string' ? url : url.url;
+
+        if (urlString.startsWith('https://')) {
+          return createAbortablePendingFetch(() => {
+            abortCount++;
+          })(url, init);
+        }
+
+        return Promise.resolve(new Response(JSON.stringify({
+          subject: 'acct:test@example.com',
+          links: []
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/jrd+json' }
+        }));
+      };
+
+      try {
+        const timeoutWf = new WebFinger({
+          allow_private_addresses: true,
+          request_timeout: 20,
+          tls_only: false,
+          uri_fallback: false
+        });
+
+        const result = await timeoutWf.lookup('test@example.com');
+        expect(result.object.subject).toBe('acct:test@example.com');
+        expect(requestCount).toBe(2);
+        expect(abortCount).toBe(1);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('should give redirect follow-up requests their own timeout budget', async () => {
+      const originalFetch = globalThis.fetch;
+      const requestedUrls: string[] = [];
+      let abortCount = 0;
+
+      globalThis.fetch = (url: string | Request, init?: RequestInit) => {
+        const urlString = typeof url === 'string' ? url : url.url;
+        requestedUrls.push(urlString);
+
+        if (requestedUrls.length === 1) {
+          return Promise.resolve(new Response(null, {
+            status: 302,
+            headers: {
+              location: 'https://redirected.example/.well-known/webfinger?resource=acct:test@example.com'
+            }
+          }));
+        }
+
+        return createAbortablePendingFetch(() => {
+          abortCount++;
+        })(url, init);
+      };
+
+      try {
+        const timeoutWf = new WebFinger({
+          allow_private_addresses: true,
+          request_timeout: 20,
+          uri_fallback: false
+        });
+
+        await expect(timeoutWf.lookup('test@example.com'))
+          .rejects.toThrow('request timed out');
+
+        expect(requestedUrls).toEqual([
+          'https://example.com/.well-known/webfinger?resource=acct:test@example.com',
+          'https://redirected.example/.well-known/webfinger?resource=acct:test@example.com'
+        ]);
+        expect(abortCount).toBe(1);
       } finally {
         globalThis.fetch = originalFetch;
       }

--- a/src/webfinger.ts
+++ b/src/webfinger.ts
@@ -199,10 +199,30 @@ export default class WebFinger {
       throw new WebFingerError('too many redirects');
     }
 
-    const response = await fetch(url, {
-      headers: {'Accept': 'application/jrd+json, application/json'},
-      redirect: 'manual' // Handle redirects manually for security validation
-    });
+    const abortController = new AbortController();
+    let requestTimedOut = false;
+    const timeoutId = setTimeout(() => {
+      requestTimedOut = true;
+      abortController.abort();
+    }, this.config.request_timeout);
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: {'Accept': 'application/jrd+json, application/json'},
+        redirect: 'manual', // Handle redirects manually for security validation
+        signal: abortController.signal
+      });
+    } catch (error) {
+      if (requestTimedOut ||
+          (abortController.signal.aborted && error instanceof Error && error.name === 'AbortError')) {
+        throw new WebFingerError('request timed out');
+      }
+
+      throw error instanceof Error ? error : new WebFingerError(String(error));
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     // Handle redirect responses with security validation
     if (response.status >= 300 && response.status < 400) {

--- a/src/webfinger.ts
+++ b/src/webfinger.ts
@@ -65,7 +65,11 @@ export type WebFingerConfig = {
   tls_only: boolean,
   /** Enable host-meta and host-meta.json fallback endpoints. */
   uri_fallback: boolean,
-  /** Request timeout in milliseconds. */
+  /**
+   * Request timeout in milliseconds. Applied per HTTP attempt:
+   * each redirect hop and fallback URI gets a fresh budget, so the
+   * worst-case wall time is roughly (timeout) × (redirects + 1) × (URIs) × (protocols).
+   */
   request_timeout: number,
   /** Allow private/internal addresses (DANGEROUS - only for development). */
   allow_private_addresses: boolean
@@ -200,89 +204,85 @@ export default class WebFinger {
     }
 
     const abortController = new AbortController();
-    let requestTimedOut = false;
     const timeoutId = setTimeout(() => {
-      requestTimedOut = true;
       abortController.abort();
     }, this.config.request_timeout);
 
-    let response: Response;
     try {
-      response = await fetch(url, {
+      const response = await fetch(url, {
         headers: {'Accept': 'application/jrd+json, application/json'},
         redirect: 'manual', // Handle redirects manually for security validation
         signal: abortController.signal
       });
+
+      // Handle redirect responses with security validation
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get('location');
+        if (!location) {
+          throw new WebFingerError('redirect without location header');
+        }
+
+        // Parse and validate redirect URL
+        let redirectUrl: URL;
+        try {
+          redirectUrl = new URL(location, url); // Resolve relative URLs
+        } catch {
+          throw new WebFingerError('invalid redirect URL');
+        }
+
+        // Security: Validate redirect destination host
+        const redirectHost = WebFinger.validateHost(redirectUrl.hostname + (redirectUrl.port ? ':' + redirectUrl.port : ''));
+
+        // Security: Check if redirect target is private/internal address
+        if (!this.config.allow_private_addresses && WebFinger.isPrivateAddress(redirectHost)) {
+          throw new WebFingerError('redirect to private or internal address blocked');
+        }
+
+        // Clear the current timer before recursing — the recursive call gets its own budget.
+        clearTimeout(timeoutId);
+        return this.fetchJRD(redirectUrl.toString(), redirectCount + 1);
+      }
+
+      if (response.status === 404) {
+        throw new WebFingerError('resource not found', 404)
+      } else if (!response.ok) {
+        throw new WebFingerError('error during request', response.status);
+      }
+
+      // Check Content-Type for RFC 7033 compliance (informational only)
+      const contentType = response.headers.get('content-type') || '';
+      const lowerContentType = contentType.toLowerCase();
+
+      // Parse main media type (before semicolon for charset/boundary params)
+      const mainType = lowerContentType.split(';')[0].trim();
+
+      if (mainType === 'application/jrd+json') {
+        // Perfect - RFC 7033 compliant
+      } else if (mainType === 'application/json') {
+        console.debug(
+          `WebFinger: Server uses "application/json" instead of RFC 7033 recommended "application/jrd+json".`
+        );
+      } else {
+        console.warn(
+          `WebFinger: Server returned unexpected content-type "${contentType}". ` +
+          'Expected "application/jrd+json" per RFC 7033.'
+        );
+      }
+
+      const responseText = await response.text();
+
+      if (WebFinger.isValidJSON(responseText)) {
+        return responseText;
+      } else {
+        throw new WebFingerError('invalid json')
+      }
     } catch (error) {
-      if (requestTimedOut ||
-          (abortController.signal.aborted && error instanceof Error && error.name === 'AbortError')) {
+      if (abortController.signal.aborted) {
         throw new WebFingerError('request timed out');
       }
-
-      throw error instanceof Error ? error : new WebFingerError(String(error));
+      throw error;
     } finally {
       clearTimeout(timeoutId);
-    }
-
-    // Handle redirect responses with security validation
-    if (response.status >= 300 && response.status < 400) {
-      const location = response.headers.get('location');
-      if (!location) {
-        throw new WebFingerError('redirect without location header');
-      }
-
-      // Parse and validate redirect URL
-      let redirectUrl: URL;
-      try {
-        redirectUrl = new URL(location, url); // Resolve relative URLs
-      } catch {
-        throw new WebFingerError('invalid redirect URL');
-      }
-
-      // Security: Validate redirect destination host
-      const redirectHost = WebFinger.validateHost(redirectUrl.hostname + (redirectUrl.port ? ':' + redirectUrl.port : ''));
-
-      // Security: Check if redirect target is private/internal address
-      if (!this.config.allow_private_addresses && WebFinger.isPrivateAddress(redirectHost)) {
-        throw new WebFingerError('redirect to private or internal address blocked');
-      }
-
-      // Follow the redirect
-      return this.fetchJRD(redirectUrl.toString(), redirectCount + 1);
-    }
-
-    if (response.status === 404) {
-      throw new WebFingerError('resource not found', 404)
-    } else if (!response.ok) {
-      throw new WebFingerError('error during request', response.status);
-    }
-
-    // Check Content-Type for RFC 7033 compliance (informational only)
-    const contentType = response.headers.get('content-type') || '';
-    const lowerContentType = contentType.toLowerCase();
-
-    // Parse main media type (before semicolon for charset/boundary params)
-    const mainType = lowerContentType.split(';')[0].trim();
-
-    if (mainType === 'application/jrd+json') {
-      // Perfect - RFC 7033 compliant
-    } else if (mainType === 'application/json') {
-      console.debug(
-        `WebFinger: Server uses "application/json" instead of RFC 7033 recommended "application/jrd+json".`
-      );
-    } else {
-      console.warn(
-        `WebFinger: Server returned unexpected content-type "${contentType}". ` +
-        'Expected "application/jrd+json" per RFC 7033.'
-      );
-    }
-
-    const responseText = await response.text();
-
-    if (WebFinger.isValidJSON(responseText)) {
-      return responseText;
-    } else {
-      throw new WebFingerError('invalid json')
     }
   };
 


### PR DESCRIPTION
## Summary
Enforce `request_timeout` per HTTP attempt with `AbortController`, returning a stable timeout error instead of hanging indefinitely.
Add deterministic source and browser-bundle regressions for stalled requests, timeout-driven fallback, and redirect follow-up timeout handling.
Closes #161.