### PR TITLE
Align source license banner with MIT

### DIFF
--- a/src/webfinger.ts
+++ b/src/webfinger.ts
@@ -5,13 +5,10 @@
  * Developed and Maintained by:
  *   Nick Jennings <nick@silverbucket.net>
  *
- * webfinger.js is released under the AGPL (see LICENSE).
+ * webfinger.js is released under the MIT License (see LICENSE).
  *
- * You don't have to do anything special to choose one license or the other and you don't
- * have to notify anyone which license you are using.
- * Please see the corresponding license file for details of these licenses.
- * You are free to use, modify and distribute this software, but all copyright
- * information must remain.
+ * You are free to use, modify, and distribute this software under the terms
+ * of the MIT License. All copyright information must remain.
  *
  */
 


### PR DESCRIPTION
## Summary
Update the source banner in `src/webfinger.ts` to match the MIT license already declared in `LICENSE` and `package.json`.
Keep this PR source-only and leave `dist/*` regeneration for the next release build.
Closes #162.