### PR TITLE
Unify host validation pipeline for lookup and redirects (fixes #158)

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -52,14 +52,15 @@ In Node.js environments, the library performs DNS resolution to prevent attacks 
 
 ### Redirect Protection
 
-The library implements manual redirect handling to validate redirect destinations:
+The library implements manual redirect handling to validate redirect destinations through the same canonical validation pipeline used for the initial address:
 
 - **Redirect limits**: Maximum of 3 redirects to prevent redirect loops
 - **Destination validation**: All redirect targets are checked against the private address blacklist
+- **DNS resolution**: In Node.js/Bun, redirect hostnames are resolved and their IPs checked against the private blacklist — closing DNS-rebind style redirect attacks
 - **Malformed response handling**: Invalid or missing Location headers are rejected
 - **URL validation**: Redirect URLs are parsed and validated before following
 
-This prevents attacks where a public domain's WebFinger endpoint redirects to private network resources.
+This prevents attacks where a public domain's WebFinger endpoint redirects to private network resources — either via IP literal or via a hostname whose DNS records point inside the network.
 
 ## Development Override
 

--- a/src/webfinger.test.ts
+++ b/src/webfinger.test.ts
@@ -76,7 +76,7 @@ describe('WebFinger', () => {
     });
 
     it('should reject invalid URI format', async () => {
-      await expect(webfinger.lookup('http://')).rejects.toThrow('could not determine host from address');
+      await expect(webfinger.lookup('http://')).rejects.toThrow('invalid URI format');
     });
   });
 
@@ -334,6 +334,99 @@ describe('WebFinger', () => {
             ]);
           }
         } finally {
+          globalThis.fetch = originalFetch;
+        }
+      });
+
+      it('should block redirects whose hostname resolves to a private IPv4 address', async () => {
+        const originalEval = global.eval;
+        const originalProcess = global.process;
+        const originalFetch = globalThis.fetch;
+
+        global.process = { versions: { node: '18.0.0' } } as MockProcess;
+
+        let sneakyLookupAttempted = false;
+        const mockDns = {
+          resolve4: async (hostname: string) => {
+            if (hostname === 'initial-source.example') return ['8.8.8.8'];
+            if (hostname === 'sneaky-target.example') {
+              sneakyLookupAttempted = true;
+              return ['127.0.0.1'];
+            }
+            return [];
+          },
+          resolve6: async () => []
+        };
+
+        global.eval = (code: string) => {
+          if (typeof code === 'string' && code.includes('import("dns")')) {
+            return Promise.resolve({ promises: mockDns });
+          }
+          return originalEval(code);
+        };
+
+        globalThis.fetch = async () => new Response(null, {
+          status: 302,
+          headers: { location: 'https://sneaky-target.example/.well-known/webfinger' }
+        });
+
+        try {
+          const wf = new WebFinger({
+            allow_private_addresses: false,
+            request_timeout: 1000,
+            uri_fallback: false
+          });
+
+          await expect(wf.lookup('test@initial-source.example'))
+            .rejects.toThrow('redirect to private or internal address blocked');
+          expect(sneakyLookupAttempted).toBe(true);
+        } finally {
+          global.eval = originalEval;
+          global.process = originalProcess;
+          globalThis.fetch = originalFetch;
+        }
+      });
+
+      it('should block redirects whose hostname resolves to a private IPv6 address', async () => {
+        const originalEval = global.eval;
+        const originalProcess = global.process;
+        const originalFetch = globalThis.fetch;
+
+        global.process = { versions: { node: '18.0.0' } } as MockProcess;
+
+        const mockDns = {
+          resolve4: async () => [],
+          resolve6: async (hostname: string) => {
+            if (hostname === 'initial-source.example') return ['2001:db8::1'];
+            if (hostname === 'sneaky-target.example') return ['::1'];
+            return [];
+          }
+        };
+
+        global.eval = (code: string) => {
+          if (typeof code === 'string' && code.includes('import("dns")')) {
+            return Promise.resolve({ promises: mockDns });
+          }
+          return originalEval(code);
+        };
+
+        globalThis.fetch = async () => new Response(null, {
+          status: 302,
+          headers: { location: 'https://sneaky-target.example/.well-known/webfinger' }
+        });
+
+        try {
+          const wf = new WebFinger({
+            allow_private_addresses: false,
+            request_timeout: 1000,
+            uri_fallback: false
+          });
+
+          await expect(wf.lookup('test@initial-source.example'))
+            .rejects.toThrow('redirect to private or internal address blocked');
+        } finally {
+          global.eval = originalEval;
+          global.process = originalProcess;
           globalThis.fetch = originalFetch;
         }
       });

--- a/src/webfinger.ts
+++ b/src/webfinger.ts
@@ -227,12 +227,16 @@ export default class WebFinger {
           throw new WebFingerError('invalid redirect URL');
         }
 
-        // Security: Validate redirect destination host
-        const redirectHost = WebFinger.normalizeHost(redirectUrl.host).host;
-
-        // Security: Check if redirect target is private/internal address
-        if (!this.config.allow_private_addresses && WebFinger.isPrivateAddress(redirectHost)) {
-          throw new WebFingerError('redirect to private or internal address blocked');
+        // Security: run the redirect target through the same canonical pipeline
+        // as the initial lookup — includes normalization, private-IP check, and
+        // DNS resolution — so a redirect can't reach a host the caller couldn't.
+        try {
+          await this.resolveAndValidateHost(redirectUrl.host);
+        } catch (err) {
+          if (err instanceof WebFingerError) {
+            throw new WebFingerError('redirect to private or internal address blocked');
+          }
+          throw err;
         }
 
         // Clear the current timer before recursing — the recursive call gets its own budget.
@@ -434,6 +438,64 @@ export default class WebFinger {
     }
 
     return undefined;
+  };
+
+  /**
+   * Extracts the host authority from an address, deferring to the platform URL
+   * parser for URI-form addresses so userinfo, IPv6 literals, and path/query
+   * boundaries are handled consistently with {@link fetchJRD}'s redirect parsing.
+   *
+   * @private
+   * @param address - Raw address supplied by the caller (useraddress or URI)
+   * @returns Raw host as it would appear in a URL authority
+   * @throws {WebFingerError} When the address is malformed or missing a host
+   */
+  private static parseAddress(address: string): { host: string } {
+    const cleaned = address.replace(/ /g, '');
+    if (cleaned.includes('://')) {
+      let url: URL;
+      try {
+        url = new URL(cleaned);
+      } catch {
+        throw new WebFingerError('invalid URI format');
+      }
+      if (!url.hostname) {
+        throw new WebFingerError('could not determine host from address');
+      }
+      return { host: url.host };
+    }
+
+    // Useraddress form: require exactly one '@' with a non-empty host segment,
+    // matching prior behaviour (multi-'@' inputs are rejected).
+    const parts = cleaned.split('@');
+    if (parts.length !== 2 || !parts[1]) {
+      throw new WebFingerError('invalid useraddress format');
+    }
+    return { host: parts[1] };
+  };
+
+  /**
+   * Canonical host validation pipeline shared by the initial lookup and every
+   * redirect hop. Applying the same checks in the same order here ensures there
+   * is no drift between entry points — a redirect target must clear exactly the
+   * same bar as the caller-supplied address.
+   *
+   * @private
+   * @param rawHost - Authority component from an address or redirect URL
+   * @returns Canonicalized host and hostname for downstream URL building
+   * @throws {WebFingerError} When the host is syntactically invalid, resolves
+   *         to a private address, or is itself a private address (unless
+   *         {@link WebFingerConfig.allow_private_addresses} is enabled)
+   */
+  private async resolveAndValidateHost(rawHost: string): Promise<{ host: string, hostname: string }> {
+    const normalized = WebFinger.normalizeHost(rawHost);
+    if (!this.config.allow_private_addresses) {
+      if (WebFinger.isPrivateAddress(normalized.host)) {
+        throw new WebFingerError('private or internal addresses are not allowed');
+      }
+      await this.validateDNSResolution(normalized.hostname);
+    }
+    return normalized;
   };
 
   /**
@@ -653,41 +715,9 @@ export default class WebFinger {
       throw new WebFingerError('address is required');
     }
 
-    let host = '';
-    if (address.indexOf('://') > -1) {
-      // other uri format
-      const parts = address.replace(/ /g, '').split('/');
-      if (parts.length < 3) {
-        throw new WebFingerError('invalid URI format');
-      }
-      host = parts[2];
-    } else {
-      // useraddress
-      const parts = address.replace(/ /g, '').split('@');
-      if (parts.length !== 2 || !parts[1]) {
-        throw new WebFingerError('invalid useraddress format');
-      }
-      host = parts[1];
-    }
+    const { host: rawHost } = WebFinger.parseAddress(address);
+    const { host } = await this.resolveAndValidateHost(rawHost);
 
-    if (!host) {
-      throw new WebFingerError('could not determine host from address');
-    }
-
-    // Security: Validate and sanitize the host
-    const normalizedHost = WebFinger.normalizeHost(host);
-    host = normalizedHost.host;
-
-    // Security: Check for private/internal addresses to prevent SSRF
-    if (!this.config.allow_private_addresses && WebFinger.isPrivateAddress(host)) {
-      throw new WebFingerError('private or internal addresses are not allowed');
-    }
-
-    // Security: Additional DNS resolution validation for domains that might resolve to private IPs
-    if (!this.config.allow_private_addresses) {
-      // Extract hostname without port for DNS validation
-      await this.validateDNSResolution(normalizedHost.hostname);
-    }
     let uri_index = 0;      // track which URIS we've tried already
     let protocol = 'https'; // we use https by default
 


### PR DESCRIPTION
## Summary
- Centralizes address parsing and SSRF checks behind `parseAddress` (which defers URI parsing to WHATWG `new URL()`) and `resolveAndValidateHost` (normalize → isPrivateAddress → validateDNSResolution).
- Routes both the initial `lookup()` and `fetchJRD()`'s redirect branch through the same pipeline, closing a gap where DNS resolution was not validated on redirect targets — previously a redirect to a hostname whose A/AAAA record resolved to a private IP would pass unchecked.
- Adds IPv4 and IPv6 regression tests for the redirect-DNS path and updates `docs/SECURITY.md` to document the unified behavior.

## Test plan
- [x] \`bun run lint\`
- [x] \`bun run test\` (51 unit + 28 integration + 20 browser)
- [x] \`bun run test:release\` (full import matrix: Bun ESM, Node ESM, Node CJS)